### PR TITLE
Allow base 4.10

### DIFF
--- a/generic-trie.cabal
+++ b/generic-trie.cabal
@@ -25,7 +25,7 @@ extra-source-files:
 library
   exposed-modules:     Data.GenericTrie,
                        Data.GenericTrie.Internal
-  build-depends:       base             >= 4.5     && < 4.10,
+  build-depends:       base             >= 4.5     && < 4.11,
                        transformers     >= 0.2     && < 0.6,
                        containers       >= 0.4.2.1 && < 0.6
   GHC-options:         -O2 -Wall


### PR DESCRIPTION
for GHC 8.2 compatibility.