### PR TITLE
Export `ShowTrieKey`

### DIFF
--- a/src/Data/GenericTrie.hs
+++ b/src/Data/GenericTrie.hs
@@ -32,6 +32,7 @@ module Data.GenericTrie
   -- * Trie interface
     Trie
   , TrieKey
+  , ShowTrieKey
 
   -- ** Construction
   , empty

--- a/src/Data/GenericTrie/Internal.hs
+++ b/src/Data/GenericTrie/Internal.hs
@@ -16,6 +16,7 @@
 -- | Unstable implementation details
 module Data.GenericTrie.Internal
   ( TrieKey(..)
+  , ShowTrieKey(..)
   , Trie(..)
   , OrdKey(..)
   -- * Generic derivation implementation


### PR DESCRIPTION
This re-enables showing `Trie`s with user-defined key types, since 61793abe26b7f00380746ddb18dc0ffcc2aac051.
