### PR TITLE
Fix build failures, etc.

### DIFF
--- a/.github/workflows/haskell-ci.yml
+++ b/.github/workflows/haskell-ci.yml
@@ -28,9 +28,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - compiler: ghc-9.4.1
+          - compiler: ghc-9.4.2
             compilerKind: ghc
-            compilerVersion: 9.4.1
+            compilerVersion: 9.4.2
             setup-method: ghcup
             allow-failure: false
           - compiler: ghc-9.2.2
@@ -81,16 +81,6 @@ jobs:
           - compiler: ghc-7.8.4
             compilerKind: ghc
             compilerVersion: 7.8.4
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.6.2
-            compilerKind: ghc
-            compilerVersion: 7.6.2
-            setup-method: hvr-ppa
-            allow-failure: false
-          - compiler: ghc-7.4.2
-            compilerKind: ghc
-            compilerVersion: 7.4.2
             setup-method: hvr-ppa
             allow-failure: false
       fail-fast: false

--- a/generic-trie.cabal
+++ b/generic-trie.cabal
@@ -36,6 +36,7 @@ extra-source-files:
 library
   exposed-modules:     Data.GenericTrie,
                        Data.GenericTrie.Internal
+  other-modules:       Prelude
   build-depends:       base             >= 4.7.0.2 && < 4.18,
                        transformers     >= 0.2     && < 0.7,
                        containers       >= 0.4.2.1 && < 0.7

--- a/generic-trie.cabal
+++ b/generic-trie.cabal
@@ -18,9 +18,17 @@ build-type:          Simple
 cabal-version:       >=1.10
 homepage:            http://github.com/glguy/tries
 bug-reports:         http://github.com/glguy/tries/issues
-tested-with:         GHC ==7.4.2 || ==7.6.2 || ==7.8.4 || ==7.10.3 || ==8.0.2
-                      || ==8.2.2 || ==8.4.2 || ==8.6.1 || ==8.8.1 || ==8.10.7
-                      || ==9.0.2 || ==9.2.2 || ==9.4.1
+tested-with:         GHC ==7.8.4
+                      || ==7.10.3
+                      || ==8.0.2
+                      || ==8.2.2
+                      || ==8.4.2
+                      || ==8.6.1
+                      || ==8.8.1
+                      || ==8.10.7
+                      || ==9.0.2
+                      || ==9.2.2
+                      || ==9.4.2
 
 extra-source-files:
   CHANGELOG.md
@@ -28,7 +36,7 @@ extra-source-files:
 library
   exposed-modules:     Data.GenericTrie,
                        Data.GenericTrie.Internal
-  build-depends:       base             >= 4.5.1     && < 4.18,
+  build-depends:       base             >= 4.7.0.2 && < 4.18,
                        transformers     >= 0.2     && < 0.7,
                        containers       >= 0.4.2.1 && < 0.7
   GHC-options:         -O2 -Wall

--- a/src/Data/GenericTrie.hs
+++ b/src/Data/GenericTrie.hs
@@ -83,7 +83,6 @@ module Data.GenericTrie
   , OrdKey(..)
   ) where
 
-import Control.Applicative (Applicative)
 import Data.List (foldl')
 import Data.Maybe (isNothing, isJust)
 import Prelude hiding (lookup, null, filter)

--- a/src/Data/GenericTrie/Internal.hs
+++ b/src/Data/GenericTrie/Internal.hs
@@ -41,20 +41,17 @@ module Data.GenericTrie.Internal
   , GTrie(..)
   ) where
 
-import Control.Applicative (Applicative, liftA2, (<$>))
 import Data.Char (chr, ord)
 import Data.Coerce (coerce)
-import Data.Foldable (Foldable)
 import Data.IntMap (IntMap)
 #if MIN_VERSION_base(4,9,0)
 import Data.Kind (Type)
 #endif
 import Data.Map (Map)
 import Data.Maybe (isNothing)
-import Data.Traversable (Traversable,traverse)
-import Data.Word (Word)
 import GHC.Generics
 import qualified Data.Foldable as Foldable
+import qualified Data.Traversable as Traversable
 import qualified Data.IntMap as IntMap
 import qualified Data.Map as Map
 import Prelude
@@ -1144,8 +1141,12 @@ instance (Show a, GTrieKeyShow f) => Show (GTrie f a) where
 instance TrieKey k => Functor (Trie k) where
   fmap = trieMap
 
-instance TrieKey k => Foldable (Trie k) where
+instance TrieKey k => Foldable.Foldable (Trie k) where
+  foldMap = Traversable.foldMapDefault
   foldr f = trieFoldWithKey (\_ -> f)
+#if MIN_VERSION_base(4,8,0)
+  null = trieNull
+#endif
 
 instance TrieKey k => Traversable (Trie k) where
   traverse = trieTraverse

--- a/src/Prelude.hs
+++ b/src/Prelude.hs
@@ -1,0 +1,37 @@
+{-# LANGUAGE CPP #-}
+{-# LANGUAGE PackageImports #-}
+-- | This hideous module lets us avoid dealing with the fact that
+-- various functions haven't always been exported from the standard
+-- Prelude.
+module Prelude
+  ( module Prel
+#if !MIN_VERSION_base(4,18,0)
+  , Applicative (..)
+#endif
+#if !MIN_VERSION_base(4,10,0)
+  , liftA2
+#endif
+#if !MIN_VERSION_base(4,8,0)
+  , Foldable (foldMap)
+  , Traversable (traverse)
+  , Word
+  , (<$>)
+#endif
+  )
+  where
+
+import "base" Prelude as Prel
+#if !MIN_VERSION_base(4,18,0)
+import Control.Applicative (Applicative (..))
+#endif
+
+#if !MIN_VERSION_base(4,10,0)
+import Control.Applicative (liftA2)
+#endif
+
+#if !MIN_VERSION_base(4,8,0)
+import Data.Foldable (Foldable (..))
+import Data.Traversable (Traversable (..))
+import Data.Word (Word)
+import Control.Applicative ((<$>))
+#endif


### PR DESCRIPTION
* Fix build failures. This includes bumping the minimum bound on `base` to something
  `haskell-ci` could test; it seemed to have issues retrieving GHC 7.4 and GHC 7.6.

* Add missing `ShowTrieKey` instances.

* Remove redundant import warnings.

* Use `IntMap.traverseMaybeWithKey` when available.